### PR TITLE
Adding a list of components up front

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,31 @@
 
 This is a set of components that is to be used to build a Quintype Node App. This README servers as documentation of the components. Please see [malibu](https://github.com/quintype/malibu) for a reference application using this architecture.
 
+- [Breaking News](#breakingnews)
+- [BreakingNewsItem](#breakingnewsitem)
+- [Collection](#collection)
+- [ClientSideOnly](#clientsideonly)
+- [DfpAds](#dfpads)
+- [HamburgerButton](#hamburgerbutton)
+- [ImageGalleryElement](#imagegalleryelement)
+- [InfiniteScroll](#infinitescroll)
+- [InfiniteStoryBase](#infinitestorybase)
+- [LazyLoadImages](#lazyloadimages)
+- [Link](#link)
+- [LoadMoreBase](#loadmorebase)
+- [LoadMoreCollectionStories](#loadmorecollectionstories)
+- [LoadingIndicator](#loadingindicator)
+- [Menu](#menu)
+- [NavigationComponentBase](#navigationcomponentbase)
+- [ResponsiveHeroImage](#responsiveheroimage)
+- [ResponsiveImage](#responsiveimage)
+- [SearchPageBase](#searchpagebase)
+- [Search Box](#search-box)
+- [SocialShare](#socialshare)
+- [StoryElement](#storyelement)
+- [WithError](#witherror)
+- [Review Rating](#review-rating)
+
 ### BreakingNews
 This component will automatically fetch breaking news every 30 seconds, and render the provided view.
 


### PR DESCRIPTION
Some new components are added on the readme but go unnoticed.
Ideally the date of addition of component should also be added
to make a note of how old it is.