### PR TITLE
feat(native share): Add support for native share using navigator.share

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,13 +422,18 @@ import { SocialShare } from '@quintype/components';
 
 class CustomComponent extends React.Component {
 
-  getSocialCardsTemplate({fbUrl, twitterUrl, gplusUrl, linkedinUrl}) {
+  getSocialCardsTemplate({fbUrl, twitterUrl, gplusUrl, linkedinUrl, handleNativeShare}) {
     return <ul className="social-share-icons">
         <li className="social-share-icon">
           <a href={fbUrl} target="_blank">
             <img src={fbIcon} alt="fb icon"/>
           </a>
         </li>
+        {handleNativeShare && <li className="social-share-icon">
+          <button onClick={handleNativeShare}>
+            <img src={fbIcon} alt="share icon"/>
+          </button>
+        </li>}
       </ul>
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "1.54.1",
+  "version": "1.54.2-navigator-share.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "1.54.2-navigator-share.0",
+  "version": "1.54.2-navigator-share.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "1.54.1",
+  "version": "1.54.2-navigator-share.0",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "1.54.2-navigator-share.0",
+  "version": "1.54.2-navigator-share.1",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/src/components/social-share.js
+++ b/src/components/social-share.js
@@ -1,10 +1,23 @@
 import React from "react";
 import {connect} from "react-redux";
+import {get} from "lodash";
 import {withError} from './with-error';
 
 function SocialShareBase(props) {
   const fullUrl = `${props.publisherUrl}/${props.url}`;
   const hashtags = props.hashtags ? props.hashtags : '';
+  let share = get(global, ["navigator", "share"]);
+
+  function handleShare() {
+    if (share) {
+      share({
+        title: props.title,
+        url: fullUrl,
+      });
+    }
+  }
+
+  let handleShareFn = share ? handleShare : null;
 
   return React.createElement(props.template, Object.assign({
     fbUrl: `https://www.facebook.com/sharer.php?u=${fullUrl}`,
@@ -12,7 +25,8 @@ function SocialShareBase(props) {
     gplusUrl: `https://plus.google.com/share?url=${fullUrl}`,
     linkedinUrl: `https://www.linkedin.com/shareArticle?url=${fullUrl}&title=${props.title}`,
     whatsappUrl: `https://api.whatsapp.com/send?text=${fullUrl}`,
-    mailtoUrl: `mailto:${''}?subject=${props.title}&body=${fullUrl}`
+    mailtoUrl: `mailto:${''}?subject=${props.title}&body=${fullUrl}`,
+    handleShare: handleShareFn
   }, props));
 }
 

--- a/src/components/social-share.js
+++ b/src/components/social-share.js
@@ -6,18 +6,20 @@ import {withError} from './with-error';
 function SocialShareBase(props) {
   const fullUrl = `${props.publisherUrl}/${props.url}`;
   const hashtags = props.hashtags ? props.hashtags : '';
-  let share = get(global, ["navigator", "share"]);
+  
+  function getShareHandler(title, fullUrl) {
+    const navigatorShare = global.navigator && global.navigator.share;
+    if (!navigatorShare) {
+      return null;
+    }
 
-  function handleShare() {
-    if (share) {
-      share({
-        title: props.title,
+    return function handleShare() {
+      navigatorShare({
+        title: title,
         url: fullUrl,
       });
     }
   }
-
-  let handleShareFn = share ? handleShare : null;
 
   return React.createElement(props.template, Object.assign({
     fbUrl: `https://www.facebook.com/sharer.php?u=${fullUrl}`,
@@ -26,7 +28,7 @@ function SocialShareBase(props) {
     linkedinUrl: `https://www.linkedin.com/shareArticle?url=${fullUrl}&title=${props.title}`,
     whatsappUrl: `https://api.whatsapp.com/send?text=${fullUrl}`,
     mailtoUrl: `mailto:${''}?subject=${props.title}&body=${fullUrl}`,
-    handleShare: handleShareFn
+    handleShare: getShareHandler(props.title, fullUrl)
   }, props));
 }
 

--- a/src/components/social-share.js
+++ b/src/components/social-share.js
@@ -20,7 +20,7 @@ class SocialShareBase extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      canNativeShare: null
+      canNativeShare: false
     }
   }
 

--- a/src/components/social-share.js
+++ b/src/components/social-share.js
@@ -1,6 +1,5 @@
 import React from "react";
 import {connect} from "react-redux";
-import {get} from "lodash";
 import {withError} from './with-error';
 
 function getNativeShareHandler(canNativeShare, title, fullUrl) {   


### PR DESCRIPTION
https://developer.mozilla.org/en-US/docs/Web/API/Navigator/share

- Support is really poor for this right now.
- Works only in mobile.

Exposing new handler called handleNativeShare, which can be used to enable native share. Check readMe for usage. The handler will be available only if native share is supported.


