### PR TITLE
feat(api response transformer for load more stories base): Accept apiResponseTransformer as a prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ import { Link } from '@quintype/components';
 
 This component starts with a set of stories, and then provides a load more button. This calls out to `/api/v1/stories` with the properties passed via the `params` prop. The stories are concatenated with the stories in `props.data.stories`, and the contents of `props.data` are passed to the rendered template.
 
-It can accept an alternate `api` as a prop as well as `apiReponseTrasformer` which can be used to tranformer the api response before being passed to the `template`.
+It can accept an alternate `api` as a prop as well as `apiResponseTransformer` which can be used to tranformer the api response before being passed to the `template`.
 
 ```javascript
 import { LoadMoreStoriesBase } from '@quintype/components';
@@ -265,7 +265,9 @@ export function SectionPage(props) {
   return <LoadMoreStoriesBase template={SectionPageWithStories}
                               fields={"id,headline"}
                               {...props}
-                              params={{"section-id": props.data.section.id}}/>
+                              params={{"section-id": props.data.section.id}}
+                              api="/api/v1/stories"
+                              apiResponseTransformer={(response) => response.stories} />
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -252,6 +252,8 @@ import { Link } from '@quintype/components';
 
 This component starts with a set of stories, and then provides a load more button. This calls out to `/api/v1/stories` with the properties passed via the `params` prop. The stories are concatenated with the stories in `props.data.stories`, and the contents of `props.data` are passed to the rendered template.
 
+It can accept an alternate `api` as a prop as well as `apiReponseTrasformer` which can be used to tranformer the api response before being passed to the `template`.
+
 ```javascript
 import { LoadMoreStoriesBase } from '@quintype/components';
 

--- a/src/components/load-more-stories-base.js
+++ b/src/components/load-more-stories-base.js
@@ -53,7 +53,12 @@ export class LoadMoreStoriesBase extends React.Component {
       offset: this.props.numStoriesToLoad * (pageNumber - 1) + stories.length,
       limit: this.props.numStoriesToLoad || 10,
       fields: this.props.fields
-    })).json(response => response.stories || get(response, ['results', 'stories'], []));
+    })).json(response => {
+      if (this.props.apiResponseTransformer) {
+        return this.props.apiResponseTransformer(response)
+      }
+      return response.stories || get(response, ['results', 'stories'], []);
+    });
   }
 
   render() {


### PR DESCRIPTION
Accept apiResponseTransformer as a prop to transform response of api before passing to the template in LoadMoreStoriesBase.