### PR TITLE
feat(InfiniteStoryBase): a new property disableSetUrl, when set to true will not execute setUrl

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,17 @@ function StoryPage(props) {
 
 exports.StoryPage = StoryPage;
 ```
-
+doNotChangeUrl
+When the next story is focussed on, the url and title of the page is set to the next story loaded by the Infinite Story Base. If this is not required, it can be disabled by setting the prop doNotChangeUrl={true}.
+A valid use case for this: If the after the story we are showing the snapshots of the next stories but not the actual stories. Please make sure that GA is not being fired for the next story if doNotChangeUrl is set to true.
+An Example:
+```javascript
+  <InfiniteStoryBase {...props}
+                            render={StoryPageBase}
+                            loadItems={storyPageLoadItems}
+                            onItemFocus={(item) => console.log(`Story In View: ${item.story.headline}`)}
+                            doNotChangeUrl={true} />
+```
 ### LazyCollection
 
 This component can be used to render a collection, but with the components being lazy. This takes all the same options as Collection, but with a `lazyAfter` prop.

--- a/README.md
+++ b/README.md
@@ -227,9 +227,10 @@ function StoryPage(props) {
 
 exports.StoryPage = StoryPage;
 ```
-doNotChangeUrl
-When the next story is focussed on, the url and title of the page is set to the next story loaded by the Infinite Story Base. If this is not required, it can be disabled by setting the prop doNotChangeUrl={true}.
-A valid use case for this: If the after the story we are showing the snapshots of the next stories but not the actual stories. Please make sure that GA is not being fired for the next story if doNotChangeUrl is set to true.
+#### doNotChangeUrl
+When the next story is focussed on, the url and title of the page will be set to the next story loaded by the Infinite Story Base. If this is not required, it can be disabled by setting the prop doNotChangeUrl={true}.
+A valid use case for this: If the after the story, we are showing the snapshots of the next few stories, not the actual stories we dont want to change the url to the current story shown in the snapshot.
+While disabling the url updating, Please make sure that GA is not being fired for the next story if doNotChangeUrl is set to true.
 An Example:
 ```javascript
   <InfiniteStoryBase {...props}

--- a/src/components/infinite-story-base.js
+++ b/src/components/infinite-story-base.js
@@ -20,7 +20,10 @@ export class InfiniteStoryBase extends React.Component {
 
   onFocus(index) {
     const item = this.allItems()[index];
-    global.app.maybeSetUrl("/" + item.story.slug, get(item, ['story', 'seo', 'meta-title'], item.story.headline));
+
+    if(!this.props.disableSetUrl) {
+      global.app.maybeSetUrl("/" + item.story.slug, get(item, ['story', 'seo', 'meta-title'], item.story.headline));
+    }
 
     this.props.onItemFocus && this.props.onItemFocus(item, index);
 

--- a/src/components/infinite-story-base.js
+++ b/src/components/infinite-story-base.js
@@ -21,7 +21,7 @@ export class InfiniteStoryBase extends React.Component {
   onFocus(index) {
     const item = this.allItems()[index];
 
-    if(!this.props.disableSetUrl) {
+    if(!this.props.doNotChangeUrl) {
       global.app.maybeSetUrl("/" + item.story.slug, get(item, ['story', 'seo', 'meta-title'], item.story.headline));
     }
 


### PR DESCRIPTION
The context is for some publishers, in the story pages after the story we are showing a set of story snapshots created using stories fetched from InfiniteStoryPage component. The InfiniteStoryPage Component will set the url to the next story when the next story comes into focus. When the snapshot loads, the url is changed to the next story url by the InfiniteStoryPage component and we want to make this tog gable.

Example: 
        <InfiniteStoryBase
          render={this.getStoryTemplate()}
          loadItems={this.storyPageLoadItems}
          onInitialItemFocus={item => this.onInitialItemFocusHandler(item)}
          onItemFocus={() =>{}}
          **doNotChangeUrl**={true} />
This will disable updating of url and title of the page when the next story loads