### PR TITLE
fix: Passing neverHideItem from InfiniteStoryBase

### DIFF
--- a/src/components/infinite-story-base.js
+++ b/src/components/infinite-story-base.js
@@ -103,6 +103,7 @@ export class InfiniteStoryBase extends React.Component {
                            loadNext={() => this.loadMore()}
                            loadMargin={this.props.loadMargin}
                            focusCallbackAt={this.props.focusCallbackAt || 20}
-                           onFocus={(index) => this.onFocus(index)}/>
+                           onFocus={(index) => this.onFocus(index)}
+                           neverHideItem={this.props.neverHideItem}/>
   }
 }


### PR DESCRIPTION
The neverHideItem prop makes sure that the infinite scroll items are not removed from the DOM when out of the viewport. 
This prop already exists in `InfiniteScroll`, I'm just passing it from `InfiniteStoryBase` to enable this feature for story pages.
