### PR TITLE
fix: Set global polltype value to false on unmount

### DIFF
--- a/src/components/story-elements/polltype.js
+++ b/src/components/story-elements/polltype.js
@@ -9,6 +9,10 @@ class PolltypeBase extends React.Component {
     this.loadPolltypeJS();
   }
 
+  componentWillUnmount() {
+    global._polltypeAdded = false;
+  }
+
   loadPolltypeJS() {
     const source = this.props.polltypeHost.replace(/^https:|^http:/i, '') + '/embed.js';
     if (!global._polltypeAdded) {


### PR DESCRIPTION
Scenario:
Polltype element not loading in infinite scroll.

Fix: 
Set the `global._polltypeAdded` to `false` when the polltype component unmounts.