### PR TITLE
Server side login

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.24.3-beta.0",
+  "version": "2.24.3-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.24.3-beta.1",
+  "version": "2.24.3-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.24.2",
+  "version": "2.24.3-beta.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -4987,7 +4987,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -5679,7 +5679,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -5733,7 +5733,7 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -5958,7 +5958,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -12196,7 +12196,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -12392,7 +12392,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.24.3-beta.1",
+  "version": "2.24.3-beta.2",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.24.2",
+  "version": "2.24.3-beta.0",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.24.3-beta.0",
+  "version": "2.24.3-beta.1",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/src/components/social-logins/with-facebook-login.js
+++ b/src/components/social-logins/with-facebook-login.js
@@ -6,14 +6,15 @@ import { WithSocialLogin } from './with-social-login';
  * @component
  * @category Login
  */
-export function WithFacebookLogin({ appId, children, scope, emailMandatory, redirectUrl, sso }) {
+export function WithFacebookLogin({ appId, children, scope, emailMandatory, redirectUrl, sso, isBridgekeeperLogin }) {
   return React.createElement(WithSocialLogin, {
     provider: 'facebook',
     initialize: () => loadFacebookSDK(appId),
     socialLogin: () => loginWithFacebook({ scope, emailMandatory }),
     children: children,
     redirectUrl,
-    sso
+    sso,
+    isBridgekeeperLogin
   });
 }
 

--- a/src/components/social-logins/with-google-login.js
+++ b/src/components/social-logins/with-google-login.js
@@ -6,14 +6,15 @@ import { WithSocialLogin } from './with-social-login';
  * @component
  * @category Login
  */
-export function WithGoogleLogin({ clientId, children, scope, emailMandatory, redirectUrl, sso }) {
+export function WithGoogleLogin({ clientId, children, scope, emailMandatory, redirectUrl, sso, isBridgekeeperLogin }) {
   return React.createElement(WithSocialLogin, {
     provider: 'google',
     initialize: () => loadGoogleSDK(clientId, scope),
     socialLogin: () => loginWithGoogle({ emailMandatory }),
     children: children,
     redirectUrl,
-    sso
+    sso,
+    isBridgekeeperLogin
   });
 }
 

--- a/src/components/social-logins/with-linkedin-login.js
+++ b/src/components/social-logins/with-linkedin-login.js
@@ -6,14 +6,15 @@ import { WithSocialLogin } from './with-social-login';
  * @component
  * @category Login
  */
-export function WithLinkedInLogin({ clientKey, children, scope, emailMandatory, redirectUrl, sso }) {
+export function WithLinkedInLogin({ clientKey, children, scope, emailMandatory, redirectUrl, sso, isBridgekeeperLogin }) {
   return React.createElement(WithSocialLogin, {
     provider: 'linkedin',
     initialize: () => loadLinkedInSdk(clientKey, scope),
     socialLogin: () => loginWithLinkedIn({ emailMandatory }),
     children: children,
     redirectUrl,
-    sso
+    sso,
+    isBridgekeeperLogin
   });
 }
 

--- a/src/components/social-logins/with-social-login.js
+++ b/src/components/social-logins/with-social-login.js
@@ -10,7 +10,8 @@ import { postRequest } from '../api-client';
  * NOTE:
  * - Twitter and LinkedIn do not support ClientSideLogin, and thus `login()` will just redirect to the server. It also ignores the apiKey
  * - Twitter and LinkedIn do not verify presence of email on the client side. Please ask for these permissions in the app
- *
+ * - The `login()` need not be called when serverSideLoginPath is called
+ * 
  * Example
  * ```javascript
  * import { WithFacebookLogin, WithGoogleLogin, WithTwitterLogin, WithLinkedInLogin } from '@quintype/components';

--- a/src/components/social-logins/with-social-login.js
+++ b/src/components/social-logins/with-social-login.js
@@ -48,7 +48,9 @@ import { postRequest } from '../api-client';
 export class WithSocialLogin extends React.Component {
   constructor(props) {
     super(props);
-    this.serverSideLoginPath = `/login?auth-provider=${this.props.provider}&remote-host=${global.location && global.location.origin}`;
+    this.bridgekeeperServerLoginPath = `api/auth/v1/login?auth-provider=${this.props.provider}`;
+    this.defaultServerLoginPath = `/login?auth-provider=${this.props.provider}&remote-host=${global.location && global.location.origin}`;
+    this.serverLoginPath = this.props.isBridgekeeperLogin ? this.bridgekeeperServerLoginPath : this.defaultServerLoginPath;
     this.serverSideSSOLoginPath = `/login?auth-provider=${this.props.provider}&redirect-url=${this.props.sso && this.props.redirectUrl ? this.props.redirectUrl : global.location && global.location.origin}`;
   }
 
@@ -59,7 +61,7 @@ export class WithSocialLogin extends React.Component {
   render() {
     return this.props.children({
       login: props => this.props.socialLogin.call(this, props).then(token => createSession(this.props.provider, token)),
-      serverSideLoginPath: this.props.sso ? this.serverSideSSOLoginPath : this.serverSideLoginPath
+      serverSideLoginPath: this.props.sso ? this.serverSideSSOLoginPath : this.serverLoginPath
     });
   }
 }
@@ -84,7 +86,7 @@ WithSocialLogin.defaultProps = {
   initialize: () => {},
   // function is rebound in WithSocialLogin
   socialLogin: function() {
-    const url = this.props.sso ? this.serverSideSSOLoginPath : this.serverSideLoginPath;
+    const url = this.props.sso ? this.serverSideSSOLoginPath : this.serverLoginPath;
     window.location = url;
     return Promise.reject('EXPECT_REDIRECT');
   },

--- a/src/components/social-logins/with-social-login.js
+++ b/src/components/social-logins/with-social-login.js
@@ -90,5 +90,6 @@ WithSocialLogin.defaultProps = {
     window.location = url;
     return Promise.reject('EXPECT_REDIRECT');
   },
-  sso: false
+  sso: false,
+  isBridgekeeperLogin: false
 }

--- a/src/components/social-logins/with-social-login.js
+++ b/src/components/social-logins/with-social-login.js
@@ -26,7 +26,7 @@ import { postRequest } from '../api-client';
  *       <img src={assetify(facebookIcon)} />
  *     </a>
  * }</WithFacebookLogin>
- * <WithGoogleLogin clientId="clientId" scope="email" emailMandatory>{({ login, serverSideLoginPath }) =>
+ * <WithGoogleLogin clientId="clientId" scope="email" emailMandatory isBridgekeeperLogin={true}>{({ login, serverSideLoginPath }) =>
  *     <a href={serverSideLoginPath} onClick={e => socialLogin(e, login)}>
  *       <img src={assetify(gplusIcon)} />
  *     </a>
@@ -80,7 +80,8 @@ WithSocialLogin.propTypes = {
   children: PropTypes.func.isRequired,
   provider: PropTypes.string.isRequired,
   sso: PropTypes.bool,
-  redirectUrl: PropTypes.string
+  redirectUrl: PropTypes.string,
+  isBridgekeeperLogin: PropTypes.bool,
 };
 
 WithSocialLogin.defaultProps = {

--- a/src/components/social-logins/with-twitter-login.js
+++ b/src/components/social-logins/with-twitter-login.js
@@ -6,11 +6,12 @@ import { WithSocialLogin } from './with-social-login';
  * @component
  * @category Login
  */
-export function WithTwitterLogin({ clientId, children, scope, emailMandatory, redirectUrl, sso }) {
+export function WithTwitterLogin({ clientId, children, scope, emailMandatory, redirectUrl, sso, isBridgekeeperLogin }) {
   return React.createElement(WithSocialLogin, {
     provider: 'twitter',
     children: children,
     redirectUrl,
-    sso
+    sso,
+    isBridgekeeperLogin
   });
 }


### PR DESCRIPTION
# Description

This ticket adds the server side login API from bridgekeeper and supported via toggle. This is to handle the login for NL. There is a separate ticket to move all the apis to BrK.

Fixes https://github.com/quintype/ace-planning/issues/130

Documentation: Will be sending another PR, adding before releasing the version.

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
