### PR TITLE
With member update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.26.2-with-member-update.1",
+  "version": "2.26.2-with-member-update.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.26.2-with-member-update.0",
+  "version": "2.26.2-with-member-update.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.26.1",
+  "version": "2.26.2-with-member-update.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.26.1",
+  "version": "2.26.2-with-member-update.0",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.26.2-with-member-update.0",
+  "version": "2.26.2-with-member-update.1",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.26.2-with-member-update.1",
+  "version": "2.26.2-with-member-update.2",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/src/components/with-member.js
+++ b/src/components/with-member.js
@@ -14,10 +14,14 @@ class WithMemberBase extends React.Component {
 
   checkForMemberUpdated() {
     this.props.memberBeingLoaded();
-    return getRequest('/api/v1/members/me')
+    const requestUrl = this.props.isBridgekeeperEnabled ? "/api/auth/v1/users/me" : "/api/v1/members/me";
+    return getRequest(requestUrl)
       .forbidden(() => this.props.memberUpdated(null))
       .unauthorized(() => this.props.memberUpdated(null))
-      .json(({ member }) => this.props.memberUpdated(member))
+      .json(({ member, user }) => {
+        const memberObj = this.props.isBridgekeeperEnabled ? user : member;
+        this.props.memberUpdated(memberObj)
+      })
   }
 
   componentDidMount() {
@@ -45,11 +49,12 @@ function mapStateToProps({member, memberLoading}) {
   }
 }
 
-function mapDispatchToProps(dispatch) {
+function mapDispatchToProps(dispatch, ownProps) {
+  const logoutRequestUrl = ownProps.isBridgekeeperEnabled ? "/api/auth/v1/logout" : "/api/logout";
   return {
     memberBeingLoaded: () => dispatch({ type: MEMBER_BEING_LOADED }),
     memberUpdated: member => dispatch({ type: MEMBER_UPDATED, member }),
-    logout: () => getRequest('/api/logout').res(() => dispatch({ type: MEMBER_UPDATED, member: null }))
+    logout: () => getRequest(logoutRequestUrl).res(() => dispatch({ type: MEMBER_UPDATED, member: null }))
   };
 }
 

--- a/src/components/with-member.js
+++ b/src/components/with-member.js
@@ -38,8 +38,14 @@ class WithMemberBase extends React.Component {
 }
 
 WithMemberBase.propTypes = {
-  children: PropTypes.func.isRequired
+  children: PropTypes.func.isRequired,
+  /** Enabling this prop makes the relevant bridgekeeper calls for checking the member and the logout api */
+  isBridgekeeperEnabled: PropTypes.bool
 };
+
+WithMemberBase.defaultProps = {
+  isBridgekeeperEnabled: false
+}
 
 function mapStateToProps({member, memberLoading}) {
   return {
@@ -66,6 +72,8 @@ function mapDispatchToProps(dispatch, ownProps) {
  * On initial load, the `isLoading` prop will be set, which will become false when the user is loaded. Use this field to avoid showing a Login Button while fetch is happening.
  *
  * In order to update the current member, call `checkForMemberUpdated`.
+ *
+ * In order to make bridgekeeper api calls for the current member and logout, `isBridgekeeperEnabled` prop needs to set to true. The default value is `false`.
  *
  * Example
  * ```javascript


### PR DESCRIPTION
# Description

This PR adds support for calling bridgekeeper apis for member and logout. This is handled via a toggle passed from the app where the `WithMember` component is called.

Fixes: https://github.com/quintype/ace-planning/issues/309

Documentation: The corresponding documentation is present in the pr.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

This has been tested with newslaundry staging.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
