### PR TITLE
feat: support nestedCollectionLimit in wrapCollectionLayout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.27.2",
+  "version": "2.28.0-support-nestedCollectionLimit.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.27.2",
+  "version": "2.28.0-support-nestedCollectionLimit.0",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/src/components/wrap-collection-layout.js
+++ b/src/components/wrap-collection-layout.js
@@ -75,6 +75,11 @@ export function wrapCollectionLayout(component) {
   if(component.storyLimit) {
     wrappedComponent.storyLimit = component.storyLimit;
   }
+
+  if(component.nestedCollectionLimit) {
+    wrappedComponent.nestedCollectionLimit = component.nestedCollectionLimit;
+  }
+  
   return wrappedComponent;
 }
 


### PR DESCRIPTION
# Description
https://github.com/quintype/ace-planning/issues/18
nestedCollectionLimit key to be supported in wrapCollectionLayout. This is to support passing nestedCollectionLimit from a component level similar to storyLimit

https://github.com/quintype/malibu/pull/736


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
