### PR TITLE
fix: linting | add defensive check in collectionToStories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5361,7 +5361,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -5975,7 +5975,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -6029,7 +6029,7 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -6247,7 +6247,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -12614,7 +12614,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -12810,7 +12810,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.29.0",
+  "version": "2.29.1-collectionToStories.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.29.0",
+  "version": "2.29.1-collectionToStories.0",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/src/components/wrap-collection-layout.js
+++ b/src/components/wrap-collection-layout.js
@@ -1,39 +1,51 @@
-import React from 'react';
-import {connect} from 'react-redux';
+import React from "react";
+import { connect } from "react-redux";
 import get from "lodash/get";
 
-import { LoadMoreCollectionStories } from './load-more-collection-stories';
-import { LazyLoadImages } from './lazy-load-images';
-import { ClientSideOnly } from './client-side-only';
+import { LoadMoreCollectionStories } from "./load-more-collection-stories";
+import { LazyLoadImages } from "./lazy-load-images";
+import { ClientSideOnly } from "./client-side-only";
 
-function loadMoreWrapper(Component, data, enableLoadMoreButton, slug, numStoriesToLoad) {
-  return !enableLoadMoreButton ?
-    React.createElement(Component, data) :
-    React.createElement(LoadMoreCollectionStories, {
-      template: Component,
-      collectionSlug: slug,
-      params: { 'item-type': 'story' },
-      data: data,
-      numStoriesToLoad,
-    });
+function loadMoreWrapper(
+  Component,
+  data,
+  enableLoadMoreButton,
+  slug,
+  numStoriesToLoad
+) {
+  return !enableLoadMoreButton
+    ? React.createElement(Component, data)
+    : React.createElement(LoadMoreCollectionStories, {
+        template: Component,
+        collectionSlug: slug,
+        params: { "item-type": "story" },
+        data: data,
+        numStoriesToLoad,
+      });
 }
 
-function lazyLoadWrapper(component, {lazy_load_images: lazyLoadImages = false}) {
-  return !lazyLoadImages ?
-    component :
-    React.createElement(LazyLoadImages, {}, component);
+function lazyLoadWrapper(
+  component,
+  { lazy_load_images: lazyLoadImages = false }
+) {
+  return !lazyLoadImages
+    ? component
+    : React.createElement(LazyLoadImages, {}, component);
 }
 
-function clientSideLoadWrapper(component, {client_side_only: clientSideOnly = false}) {
-  return !clientSideOnly ?
-    component :
-    React.createElement(ClientSideOnly, {}, component);
+function clientSideLoadWrapper(
+  component,
+  { client_side_only: clientSideOnly = false }
+) {
+  return !clientSideOnly
+    ? component
+    : React.createElement(ClientSideOnly, {}, component);
 }
 
 function WrapCollectionComponent(Component) {
-  return function(props) {
+  return function (props) {
     if (!props.collection) {
-      return <div></div>
+      return <div></div>;
     }
 
     const associatedMetadata = props.collection["associated-metadata"] || {};
@@ -47,10 +59,20 @@ function WrapCollectionComponent(Component) {
       associatedMetadata: associatedMetadata,
     });
 
-    const component = loadMoreWrapper(Component, data, associatedMetadata.enable_load_more_button, props.collection.slug, associatedMetadata.subsequent_stories_load_count || 10);
+    const component = loadMoreWrapper(
+      Component,
+      data,
+      associatedMetadata.enable_load_more_button,
+      props.collection.slug,
+      associatedMetadata.subsequent_stories_load_count || 10
+    );
 
-    return [clientSideLoadWrapper, lazyLoadWrapper].reduce((accumulator, currentElement) => currentElement(accumulator, associatedMetadata), component);
-  }
+    return [clientSideLoadWrapper, lazyLoadWrapper].reduce(
+      (accumulator, currentElement) =>
+        currentElement(accumulator, associatedMetadata),
+      component
+    );
+  };
 }
 
 /**
@@ -71,42 +93,53 @@ function WrapCollectionComponent(Component) {
  * @returns {Component} A component which can be passed collection
  */
 export function wrapCollectionLayout(component) {
-  const wrappedComponent = connect((state) => ({config: state.qt.config}))(WrapCollectionComponent(component));
-  if(component.storyLimit) {
+  const wrappedComponent = connect((state) => ({ config: state.qt.config }))(
+    WrapCollectionComponent(component)
+  );
+  if (component.storyLimit) {
     wrappedComponent.storyLimit = component.storyLimit;
   }
 
-  if(component.nestedCollectionLimit) {
+  if (component.nestedCollectionLimit) {
     wrappedComponent.nestedCollectionLimit = component.nestedCollectionLimit;
   }
-  
+
   return wrappedComponent;
 }
 
 /**
  * Use this function to get the stories from a collection object
+ * returns null if collection doesn't have items key
  *
  * @param {Collection} collection
  * @category Collection Page
  * @returns {Array} An array of stories
  */
 export function collectionToStories(collection) {
+  if (!collection.items) return null;
   return collection.items
-                   .filter(item => item.type === 'story')
-                   .map(item => replaceWithAlternates(item.story));
+    .filter((item) => item.type === "story")
+    .map((item) => replaceWithAlternates(item.story));
 }
 
 function replaceWithAlternates(story) {
   const alternates = get(story, ["alternative", "home", "default"]);
 
-  if(!alternates)
-    return story;
+  if (!alternates) return story;
 
   return Object.assign({}, story, {
-    headline                 : alternates.headline || story.headline,
-    "hero-image-s3-key"      : alternates["hero-image"] ? alternates["hero-image"]["hero-image-s3-key"] : story["hero-image-s3-key"],
-    "hero-image-metadata"    : alternates["hero-image"] ? alternates["hero-image"]["hero-image-metadata"] : story["hero-image-metadata"],
-    "hero-image-caption"     : alternates["hero-image"] ? alternates["hero-image"]["hero-image-caption"] : story["hero-image-caption"],
-    "hero-image-attribution" : alternates["hero-image"] ? alternates["hero-image"]["hero-image-attribution"] : story["hero-image-attribution"],
-  })
+    headline: alternates.headline || story.headline,
+    "hero-image-s3-key": alternates["hero-image"]
+      ? alternates["hero-image"]["hero-image-s3-key"]
+      : story["hero-image-s3-key"],
+    "hero-image-metadata": alternates["hero-image"]
+      ? alternates["hero-image"]["hero-image-metadata"]
+      : story["hero-image-metadata"],
+    "hero-image-caption": alternates["hero-image"]
+      ? alternates["hero-image"]["hero-image-caption"]
+      : story["hero-image-caption"],
+    "hero-image-attribution": alternates["hero-image"]
+      ? alternates["hero-image"]["hero-image-attribution"]
+      : story["hero-image-attribution"],
+  });
 }

--- a/src/components/wrap-collection-layout.js
+++ b/src/components/wrap-collection-layout.js
@@ -109,14 +109,14 @@ export function wrapCollectionLayout(component) {
 
 /**
  * Use this function to get the stories from a collection object
- * returns null if collection doesn't have items key
+ * returns [] if collection doesn't have items key
  *
  * @param {Collection} collection
  * @category Collection Page
  * @returns {Array} An array of stories
  */
 export function collectionToStories(collection) {
-  if (!collection.items) return null;
+  if (!collection.items) return [];
   return collection.items
     .filter((item) => item.type === "story")
     .map((item) => replaceWithAlternates(item.story));


### PR DESCRIPTION
collectionToStories throws exception if `items` key isn't present in collection.
We faced this issue in child collections when depth was set to 1

related PR > https://github.com/quintype/quintype-node-arrow/pull/721