### PR TITLE
Bugfix hero image

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.29.2",
+  "version": "2.29.3-bugfix-hero-image.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.29.3-bugfix-hero-image.0",
+  "version": "2.29.3-bugfix-hero-image.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5361,7 +5361,7 @@
     },
     "fs-access": {
       "version": "1.0.1",
-      "resolved": "http://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fs-access/-/fs-access-1.0.1.tgz",
       "integrity": "sha1-1qh/JiJxzv6+wwxVNAf7mV2od3o=",
       "dev": true,
       "requires": {
@@ -5975,7 +5975,7 @@
         },
         "camelcase-keys": {
           "version": "2.1.0",
-          "resolved": "http://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
           "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
           "dev": true,
           "requires": {
@@ -6029,7 +6029,7 @@
         },
         "meow": {
           "version": "3.7.0",
-          "resolved": "http://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
           "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
           "dev": true,
           "requires": {
@@ -6247,7 +6247,7 @@
       "dependencies": {
         "pify": {
           "version": "2.3.0",
-          "resolved": "http://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
@@ -12614,7 +12614,7 @@
     },
     "strip-eof": {
       "version": "1.0.0",
-      "resolved": "http://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
       "dev": true
     },
@@ -12810,7 +12810,7 @@
     },
     "through": {
       "version": "2.3.8",
-      "resolved": "http://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
       "dev": true
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.29.2",
+  "version": "2.29.3-bugfix-hero-image.0",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.29.3-bugfix-hero-image.0",
+  "version": "2.29.3-bugfix-hero-image.1",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/src/components/__snapshots__/responsive-hero-image.spec.js.snap
+++ b/src/components/__snapshots__/responsive-hero-image.spec.js.snap
@@ -19,12 +19,3 @@ exports[`ResponsiveHeroImage Picks story data when both story's hero image and a
   srcset="//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=250&auto=format%2Ccompress 250w,//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=480&auto=format%2Ccompress 480w,//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=640&auto=format%2Ccompress 640w"
 />
 `;
-
-exports[`ResponsiveHeroImage Returns undefined slug when the story prop is not passed 1`] = `
-<img
-  class="qt-image"
-  sizes="(max-width: 500px) 98vw, (max-width: 768px) 48vw, 23vw"
-  src="//images.assettype.com/undefined?w=480&auto=format%2Ccompress"
-  srcset="//images.assettype.com/undefined?w=250&auto=format%2Ccompress 250w,//images.assettype.com/undefined?w=480&auto=format%2Ccompress 480w,//images.assettype.com/undefined?w=640&auto=format%2Ccompress 640w"
-/>
-`;

--- a/src/components/responsive-hero-image.js
+++ b/src/components/responsive-hero-image.js
@@ -4,7 +4,10 @@ import omit from "@babel/runtime/helpers/objectWithoutProperties";
 import get from "lodash/get";
 
 /**
- * This component is a wrapper over {@link ResponsiveImages}. It accepts story as a prop and renders story's hero image, if hero image is absent then renders alternate hero-image of the story. If story's hero image is present it picks the alt text from the story headline else it picks from alternate headline.
+ * This component is a wrapper over {@link ResponsiveImages}. It accepts story as a prop and renders story's hero image.
+ * If hero-image-s3-key is present, it takes that as slug and the story headline as image alt text.
+ * Else it takes the slug from the alternate hero-image, alt text as alternate headline.
+ * If both are absent, it doesn't render
  *
  * ```javascript
  * import { ResponsiveHeroImage } from '@quintype/components';
@@ -19,13 +22,32 @@ import get from "lodash/get";
  * @category Images
  */
 export function ResponsiveHeroImage(props) {
-  const storyAlternateData = get(props, ["story", "alternative", "home", "default"]) || {};
-  const { headline: altHeadline } = storyAlternateData;
-  const { "hero-image-s3-key": altHeroImage, "hero-image-metadata": altMetadata } = get(storyAlternateData, ["hero-image"]) || {};
-  const heroImage = get(props, ["story", "hero-image-s3-key"]);
-  const slug = heroImage || altHeroImage;
-  const metadata = heroImage ? get(props, ["story", "hero-image-metadata"]) : altMetadata;
-  const alternateText = heroImage ? get(props, ["story", "headline"]) : altHeadline;
+  let metadata, slug, alternateText;
+  const heroImageS3Key = get(props, ["story", "hero-image-s3-key"], "");
+  const storyAlternateData = get(
+    props,
+    ["story", "alternative", "home", "default"],
+    {}
+  );
+  const alternateHeroImageS3Key = get(
+    storyAlternateData,
+    ["hero-image", "hero-image-s3-key"],
+    ""
+  );
+
+  if (heroImageS3Key) {
+    slug = heroImageS3Key;
+    metadata = get(props, ["story", "hero-image-metadata"], {});
+    alternateText = get(props, ["story", "headline"], "");
+  } else if (alternateHeroImageS3Key) {
+    slug = alternateHeroImageS3Key;
+    metadata = get(
+      storyAlternateData,
+      ["hero-image", "hero-image-metadata"],
+      {}
+    );
+    alternateText = get(storyAlternateData, ["headline"], "");
+  } else return null;
 
   return React.createElement(
     ResponsiveImage,

--- a/src/components/responsive-hero-image.js
+++ b/src/components/responsive-hero-image.js
@@ -24,11 +24,8 @@ import get from "lodash/get";
 export function ResponsiveHeroImage(props) {
   let metadata, slug, alternateText;
   const heroImageS3Key = get(props, ["story", "hero-image-s3-key"], "");
-  const storyAlternateData = get(
-    props,
-    ["story", "alternative", "home", "default"],
-    {}
-  );
+  const storyAlternateData =
+    get(props, ["story", "alternative", "home", "default"], {}) || {};
   const alternateHeroImageS3Key = get(
     storyAlternateData,
     ["hero-image", "hero-image-s3-key"],

--- a/src/components/responsive-hero-image.spec.js
+++ b/src/components/responsive-hero-image.spec.js
@@ -3,6 +3,7 @@ import { Provider } from "react-redux";
 import { createStore } from "redux";
 import { render, cleanup } from "react-testing-library";
 import React from "react";
+import cloneDeep from "lodash/cloneDeep";
 
 afterEach(cleanup);
 
@@ -12,8 +13,8 @@ const story = {
     width: 760,
     height: 427,
     "focus-point": [306, 125],
-    },
-  "headline": "Text",
+  },
+  headline: "Text",
   alternative: {
     home: {
       default: {
@@ -34,7 +35,11 @@ const story = {
 describe("ResponsiveHeroImage", () => {
   it("Picks alternate data if story's hero-image is absent", () => {
     const { container } = render(
-      <Provider store={createStore((x) => x, { qt: { config: {'cdn-image': "images.assettype.com"} } })}>
+      <Provider
+        store={createStore((x) => x, {
+          qt: { config: { "cdn-image": "images.assettype.com" } },
+        })}
+      >
         <ResponsiveHeroImage
           story={story}
           aspectRatio={[16, 9]}
@@ -46,17 +51,25 @@ describe("ResponsiveHeroImage", () => {
       </Provider>
     );
     const image = container.firstChild;
-    expect(image.getAttribute("src")).toBe("//images.assettype.com/somepublisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=480&auto=format%2Ccompress");
-    expect(image.getAttribute("srcset")).toBe("//images.assettype.com/somepublisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=250&auto=format%2Ccompress 250w,//images.assettype.com/somepublisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=480&auto=format%2Ccompress 480w,//images.assettype.com/somepublisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=640&auto=format%2Ccompress 640w");
+    expect(image.getAttribute("src")).toBe(
+      "//images.assettype.com/somepublisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=480&auto=format%2Ccompress"
+    );
+    expect(image.getAttribute("srcset")).toBe(
+      "//images.assettype.com/somepublisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=250&auto=format%2Ccompress 250w,//images.assettype.com/somepublisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=480&auto=format%2Ccompress 480w,//images.assettype.com/somepublisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=640&auto=format%2Ccompress 640w"
+    );
     expect(image.getAttribute("alt")).toBe("Alt Text");
     expect(image).toMatchSnapshot();
   });
 
   it("Picks story data when both story's hero image and alternate hero image is present", () => {
     const { container } = render(
-      <Provider store={createStore((x) => x, { qt: { config: {'cdn-image': "images.assettype.com"} } })}>
+      <Provider
+        store={createStore((x) => x, {
+          qt: { config: { "cdn-image": "images.assettype.com" } },
+        })}
+      >
         <ResponsiveHeroImage
-          story={{...story, "hero-image-s3-key": "publisher/image.png" }}
+          story={{ ...story, "hero-image-s3-key": "publisher/image.png" }}
           aspectRatio={[16, 9]}
           defaultWidth={480}
           widths={[250, 480, 640]}
@@ -66,15 +79,23 @@ describe("ResponsiveHeroImage", () => {
       </Provider>
     );
     const image = container.firstChild;
-    expect(image.getAttribute("src")).toBe("//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=480&auto=format%2Ccompress");
-    expect(image.getAttribute("srcset")).toBe("//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=250&auto=format%2Ccompress 250w,//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=480&auto=format%2Ccompress 480w,//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=640&auto=format%2Ccompress 640w");
+    expect(image.getAttribute("src")).toBe(
+      "//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=480&auto=format%2Ccompress"
+    );
+    expect(image.getAttribute("srcset")).toBe(
+      "//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=250&auto=format%2Ccompress 250w,//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=480&auto=format%2Ccompress 480w,//images.assettype.com/publisher%2Fimage.png?rect=0%2C0%2C759%2C427&w=640&auto=format%2Ccompress 640w"
+    );
     expect(image.getAttribute("alt")).toBe("Text");
     expect(image).toMatchSnapshot();
   });
 
-  it("Returns undefined slug when the story prop is not passed", () => {
+  it("Does not render if the story prop is not passed", () => {
     const { container } = render(
-      <Provider store={createStore((x) => x, { qt: { config: {'cdn-image': "images.assettype.com"} } })}>
+      <Provider
+        store={createStore((x) => x, {
+          qt: { config: { "cdn-image": "images.assettype.com" } },
+        })}
+      >
         <ResponsiveHeroImage
           story={{}}
           aspectRatio={[16, 9]}
@@ -86,9 +107,29 @@ describe("ResponsiveHeroImage", () => {
       </Provider>
     );
     const image = container.firstChild;
-    expect(image.getAttribute("src")).toBe("//images.assettype.com/undefined?w=480&auto=format%2Ccompress");
-    expect(image.getAttribute("srcset")).toBe("//images.assettype.com/undefined?w=250&auto=format%2Ccompress 250w,//images.assettype.com/undefined?w=480&auto=format%2Ccompress 480w,//images.assettype.com/undefined?w=640&auto=format%2Ccompress 640w");
-    expect(image.getAttribute("alt")).toBe(null);
-    expect(image).toMatchSnapshot();
+    expect(image).toBe(null);
+  });
+
+  it("Does not render if the story has no hero image and alternate hero image isn't specified", () => {
+    const mockStory = cloneDeep(story);
+    delete mockStory.alternative.home.default["hero-image"];
+    const { container } = render(
+      <Provider
+        store={createStore((x) => x, {
+          qt: { config: { "cdn-image": "images.assettype.com" } },
+        })}
+      >
+        <ResponsiveHeroImage
+          story={mockStory}
+          aspectRatio={[16, 9]}
+          defaultWidth={480}
+          widths={[250, 480, 640]}
+          sizes="(max-width: 500px) 98vw, (max-width: 768px) 48vw, 23vw"
+          imgParams={{ auto: ["format", "compress"] }}
+        />
+      </Provider>
+    );
+    const image = container.firstChild;
+    expect(image).toBe(null);
   });
 });


### PR DESCRIPTION
Fixes error `TypeError: Cannot read property 'hero-image-s3-key' of null` when a story without hero image is passed to responsive hero image

It's a part of https://github.com/quintype/ace-planning/issues/359