### PR TITLE
fix(update) : update babel config

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,10 +9,8 @@
   ],
   plugins: [
     "annotate-pure-calls",
-    "@babel/plugin-syntax-object-rest-spread",
     "transform-react-remove-prop-types",
-    "@babel/plugin-transform-runtime",
-    "@babel/plugin-proposal-class-properties"
+    "@babel/plugin-transform-runtime"
   ]
 }
 


### PR DESCRIPTION
While generating the docs html, its throwing  an error`NODE_ENV=development parcel build docs/entry.js --out-dir docs/build
:rotating_light: /Users/athira/qt/quintype-node-components/docs/entry.js: Duplicate plugin/preset detected.
If you'd like to use two separate instances of a plugin,`. 
 While debugging we got to know that babel>=7 does not require "@babel/plugin-proposal-class-properties", "@babel/plugin-syntax-object-rest-spread". This plugin is included in @babel/preset-env.  

Dependencies # (dependency-issue-reference)

Documentation # (link to the corresponding documentation changes)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test Case A
- [ ] Test Case B


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
