### PR TITLE
Add srcset attribute to img tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.4",
+  "version": "2.31.4-enable-srcset.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.1",
+  "version": "2.31.4-enable-srcset.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.3",
+  "version": "2.31.4-enable-srcset.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.2",
+  "version": "2.31.4-enable-srcset.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.0",
+  "version": "2.31.4-enable-srcset.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.3",
+  "version": "2.31.4-enable-srcset.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.3",
+  "version": "2.31.4-enable-srcset.0",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.0",
+  "version": "2.31.4-enable-srcset.1",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.4",
+  "version": "2.31.4-enable-srcset.5",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.2",
+  "version": "2.31.4-enable-srcset.3",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.3",
+  "version": "2.31.4-enable-srcset.4",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@quintype/components",
-  "version": "2.31.4-enable-srcset.1",
+  "version": "2.31.4-enable-srcset.2",
   "description": "Components to help build Quintype Node.js apps",
   "main": "dist/cjs/index.js",
   "module": "dist/es/index.js",

--- a/src/components/impl/gumlet-image.js
+++ b/src/components/impl/gumlet-image.js
@@ -31,9 +31,9 @@ export function GumletImage(props) {
   const imageProps = {
     src: emptyWebGif,
     "data-src": "https://" + imageCDN + "/" + image.path(aspectRatio, imgParams),
-    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)} 300w,
-    https://${imageCDN}/${image.path(aspectRatio, imgParams)} 768w,
-    https://${imageCDN}/${image.path(aspectRatio, imgParams)} 1080w,`,
+    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)}?w=300 300w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)}?w=300 768w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)}?w=300 1080w,`,
     key: hashString(slug)
   };
 

--- a/src/components/impl/gumlet-image.js
+++ b/src/components/impl/gumlet-image.js
@@ -31,8 +31,8 @@ export function GumletImage(props) {
   const imageProps = {
     src: emptyWebGif,
     "data-src": "https://" + imageCDN + "/" + image.path(aspectRatio, imgParams),
-    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=320 320w,
-    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=640 640w,
+    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=480 480w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=720 720w,
     https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=1024 1024w,`,
     key: hashString(slug)
   };

--- a/src/components/impl/gumlet-image.js
+++ b/src/components/impl/gumlet-image.js
@@ -31,9 +31,9 @@ export function GumletImage(props) {
   const imageProps = {
     src: emptyWebGif,
     "data-src": "https://" + imageCDN + "/" + image.path(aspectRatio, imgParams),
-    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=300 300w,
-    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=768 768w,
-    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=1080 1080w,`,
+    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=320 320w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=640 640w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=1024 1024w,`,
     key: hashString(slug)
   };
 

--- a/src/components/impl/gumlet-image.js
+++ b/src/components/impl/gumlet-image.js
@@ -31,9 +31,9 @@ export function GumletImage(props) {
   const imageProps = {
     src: emptyWebGif,
     "data-src": "https://" + imageCDN + "/" + image.path(aspectRatio, imgParams),
-    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)}?w=300 300w,
-    https://${imageCDN}/${image.path(aspectRatio, imgParams)}?w=300 768w,
-    https://${imageCDN}/${image.path(aspectRatio, imgParams)}?w=300 1080w,`,
+    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=300 300w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=768 768w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=1080 1080w,`,
     key: hashString(slug)
   };
 

--- a/src/components/impl/gumlet-image.js
+++ b/src/components/impl/gumlet-image.js
@@ -31,8 +31,8 @@ export function GumletImage(props) {
   const imageProps = {
     src: emptyWebGif,
     "data-src": "https://" + imageCDN + "/" + image.path(aspectRatio, imgParams),
-    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=480 480w,
-    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=720 720w,
+    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=320 320w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=640 640w,
     https://${imageCDN}/${image.path(aspectRatio, imgParams)}&w=1024 1024w,`,
     key: hashString(slug)
   };

--- a/src/components/impl/gumlet-image.js
+++ b/src/components/impl/gumlet-image.js
@@ -1,24 +1,26 @@
-import React, { useEffect } from "react";
-import emptyWebGif from 'empty-web-gif';
+import omit from "@babel/runtime/helpers/objectWithoutProperties";
+import emptyWebGif from "empty-web-gif";
 import { FocusedImage } from "quintype-js";
+import React, { useEffect } from "react";
 import { hashString, USED_PARAMS } from "./image-utils";
-import omit from '@babel/runtime/helpers/objectWithoutProperties';
 
 let forceLoadingGumlet = false;
 function loadGumlet() {
-  if(window.GUMLET_CONFIG || window.gumlet || forceLoadingGumlet === true) {
+  if (window.GUMLET_CONFIG || window.gumlet || forceLoadingGumlet === true) {
     return;
   }
-  if (process.env.NODE_ENV == 'development') {
-    console.warn("Loading Gumlet Dynamically! This is really bad for page speed. Please see https://developers.quintype.com/malibu/tutorial/gumlet-integration");
+  if (process.env.NODE_ENV == "development") {
+    console.warn(
+      "Loading Gumlet Dynamically! This is really bad for page speed. Please see https://developers.quintype.com/malibu/tutorial/gumlet-integration"
+    );
   }
   forceLoadingGumlet = true;
   window.GUMLET_CONFIG = window.GUMLET_CONFIG || {
     hosts: []
-  }
-  const script = document.createElement('script');
-  script.type = 'text/javascript';
-  script.src = 'https://cdn.gumlet.com/gumlet.js/2.0/gumlet.min.js';
+  };
+  const script = document.createElement("script");
+  script.type = "text/javascript";
+  script.src = "https://cdn.gumlet.com/gumlet.js/2.0/gumlet.min.js";
   document.body.appendChild(script);
 }
 
@@ -29,6 +31,9 @@ export function GumletImage(props) {
   const imageProps = {
     src: emptyWebGif,
     "data-src": "https://" + imageCDN + "/" + image.path(aspectRatio, imgParams),
+    srcSet: `https://${imageCDN}/${image.path(aspectRatio, imgParams)} 300w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)} 768w,
+    https://${imageCDN}/${image.path(aspectRatio, imgParams)} 1080w,`,
     key: hashString(slug)
   };
 
@@ -36,10 +41,12 @@ export function GumletImage(props) {
 
   useEffect(loadGumlet);
 
-  return <React.Fragment>
-    <Tag {...imageProps} {...omit(props, USED_PARAMS)} className={className ? `qt-image ${className}` : 'qt-image'} />
-    <noscript>
-      <img src={`https://${imageCDN}/${image.path(aspectRatio, {...imgParams, w: 1200})}`} alt={props.alt || ""} />
-    </noscript>
-  </React.Fragment>
+  return (
+    <React.Fragment>
+      <Tag {...imageProps} {...omit(props, USED_PARAMS)} className={className ? `qt-image ${className}` : "qt-image"} />
+      <noscript>
+        <img src={`https://${imageCDN}/${image.path(aspectRatio, { ...imgParams, w: 1200 })}`} alt={props.alt || ""} />
+      </noscript>
+    </React.Fragment>
+  );
 }


### PR DESCRIPTION
Added `srcset` attribute to the img tag to avoid `Properly Size Images` error in pagespeed insights

Ticket Reference: https://github.com/quintype/ace-planning/issues/469

